### PR TITLE
Rename package to @nilfoundation/niljs

### DIFF
--- a/.changeset/silly-boxes-end.md
+++ b/.changeset/silly-boxes-end.md
@@ -1,0 +1,5 @@
+---
+"@nilfoundation/niljs": patch
+---
+
+Rename package because we are having an error: Package name too similar to existing package nil.js

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,27 +15,7 @@ jobs:
   version-pull-request:
     name: Version Pull Request
     runs-on: ubuntu-latest
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Install dependencies
-        uses: ./.github/actions/install-dependencies
-        with:
-          node_version: 20
-      - name: Build
-        uses: ./.github/actions/build
-      - name: Create Pull Request
-        uses: changesets/action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          title: "Version Packages"
-          commit: "version packages"
-
-  publish:
-    name: Publish
-    needs: version-pull-request
-    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       id-token: write
@@ -45,11 +26,15 @@ jobs:
         uses: ./.github/actions/install-dependencies
         with:
           node_version: 20
-      - name: Publish to NPM
+      - name: Build
+        uses: ./.github/actions/build
+      - name: Create Pull Request and Publish
         uses: changesets/action@v1
-        with:
-          createGithubReleases: true
-          publish: "npm run changeset:publish"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        with:
+          title: "Version Packages"
+          commit: "version packages"
+          createGithubReleases: true
+          publish: "npm run changeset:publish"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ### Installation
 
 ```bash
-npm install niljs
+npm install @nilfoundation/niljs
 ```
 
 ### Getting started
@@ -32,7 +32,7 @@ There are two clients in the library to interact with the Nil network.
 The first one is the `PublicClient` class, which is used to interact with the Nil network without the need for a private key. It is used to get information about the network, such as block number and block hash.
 
 ```typescript
-import { PublicClient } from "niljs";
+import { PublicClient } from "@nilfoundation/niljs";
 
 const endpoint = "https://localhost:8259";
 const publicClient = new PublicClient({ endpoint });
@@ -45,7 +45,7 @@ publicClient.getBalance("your_address").then((balance) => {
 The second one is the `WalletClient` class, which is used to interact with the Nil network with a private key. It is used to send messages to the network.
 
 ```typescript
-import { WalletClient } from "niljs";
+import { WalletClient } from "@nilfoundation/niljs";
 
 const endpoint = "https://localhost:8259";
 const walletClient = new WalletClient({ endpoint });
@@ -64,7 +64,7 @@ walletClient
 Initialize the Signer with the private key of the account you want to use to sign messages.
 
 ```typescript
-import { Signer } from "niljs";
+import { Signer } from "@nilfoundation/niljs";
 
 const privateKey = "your_private_key";
 const signer = new Signer({ privateKey });
@@ -75,8 +75,8 @@ signer.sign(new Uint8Array(32));
 You can also sign messages automatically by passing the Signer instance to the WalletClient.
 
 ```typescript
-import { WalletClient } from "niljs";
-import { Signer } from "niljs";
+import { WalletClient } from "@nilfoundation/niljs";
+import { Signer } from "@nilfoundation/niljs";
 
 const endpoint = "https://localhost:8259";
 const privateKey = "your_private_key";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "niljs",
-  "version": "0.0.1",
+  "name": "@nilfoundation/niljs",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "niljs",
-      "version": "0.0.1",
+      "name": "@nilfoundation/niljs",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@chainsafe/ssz": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "niljs",
+  "name": "@nilfoundation/niljs",
+  "author": "=nil; Foundation",
   "version": "0.1.1",
   "repository": {
     "type": "git",

--- a/rollup/rollupUtils.js
+++ b/rollup/rollupUtils.js
@@ -3,7 +3,7 @@
  */
 const createBanner = (version, year) => {
   return `/**!
- * niljs v${version}
+ * @nilfoundation/niljs v${version}
  *
  * @copyright (c) ${year} =nil; Foundation.
  *

--- a/src/clients/PublicClient.ts
+++ b/src/clients/PublicClient.ts
@@ -6,7 +6,7 @@ import type { IPublicClientConfig } from "./types/ClientConfigs.js";
  * It is an abstraction of connection to the Nil network.
  * Public client alllows to use api that does not require signing data and private key usage.
  * @example
- * import { PublicClient } from 'niljs';
+ * import { PublicClient } from '@nilfoundation/niljs';
  *
  * const client = new PublicClient({
  *  endpoint: 'http://127.0.0.1:8529'
@@ -23,7 +23,7 @@ class PublicClient extends BaseClient {
    * @param number - The block number.
    * @returns The block.
    * @example
-   import { PublicClient } from 'niljs';
+   import { PublicClient } from '@nilfoundation/niljs';
    *
    * const client = new PublicClient({
    *  endpoint: 'http://127.0.0.1:8529'
@@ -45,7 +45,7 @@ class PublicClient extends BaseClient {
    * @param number - The block number.
    * @returns The block.
    * @example
-   import { PublicClient } from 'niljs';
+   import { PublicClient } from '@nilfoundation/niljs';
    *
    * const client = new PublicClient({
    *  endpoint: 'http://127.0.0.1:8529'
@@ -67,7 +67,7 @@ class PublicClient extends BaseClient {
    * @param number - The block number.
    * @returns The message count.
    * @example
-   import { PublicClient } from 'niljs';
+   import { PublicClient } from '@nilfoundation/niljs';
    *
    * const client = new PublicClient({
    *  endpoint: 'http://127.0.0.1:8529'
@@ -89,7 +89,7 @@ class PublicClient extends BaseClient {
    * @param hash - The block hash.
    * @returns The message count.
    * @example
-   import { PublicClient } from 'niljs';
+   import { PublicClient } from '@nilfoundation/niljs';
    *
    * const client = new PublicClient({
    *  endpoint: 'http://127.0.0.1:8529'
@@ -112,7 +112,7 @@ class PublicClient extends BaseClient {
    * @param blockNumberOrHash - The block number or hash.
    * @returns The code of the contract.
    * @example
-   import { PublicClient } from 'niljs';
+   import { PublicClient } from '@nilfoundation/niljs';
    *
    * const client = new PublicClient({
    *  endpoint: 'http://127.0.0.1:8529'
@@ -138,7 +138,7 @@ class PublicClient extends BaseClient {
    * @param blockNumberOrHash - The block number or hash.
    * @returns The message count.
    * @example
-   import { PublicClient } from 'niljs';
+   import { PublicClient } from '@nilfoundation/niljs';
    *
    * const client = new PublicClient({
    *  endpoint: 'http://127.0.0.1:8529'
@@ -164,7 +164,7 @@ class PublicClient extends BaseClient {
    * @param blockNumberOrHash - The block number or hash.
    * @returns The balance of the address.
    * @example
-   import { PublicClient } from 'niljs';
+   import { PublicClient } from '@nilfoundation/niljs';
    *
    * const client = new PublicClient({
    *  endpoint: 'http://127.0.0.1:8529'
@@ -189,7 +189,7 @@ class PublicClient extends BaseClient {
    * @param hash - The hash.
    * @returns The message.
    * @example
-   import { PublicClient } from 'niljs';
+   import { PublicClient } from '@nilfoundation/niljs';
    *
    * const client = new PublicClient({
    *  endpoint: 'http://127.0.0.1:8529'

--- a/src/clients/WalletClient.ts
+++ b/src/clients/WalletClient.ts
@@ -14,7 +14,7 @@ import type { ISignMessageOptions } from "./types/ISignMessageOptions.js";
  * It is an abstraction of connection to the Nil network.
  * Wallet client alllows to use api that require signing data and private key usage.
  * @example
- * import { WalletClient } from 'niljs';
+ * import { WalletClient } from '@nilfoundation/niljs';
  *
  * const client = new WalletClient({
  *  endpoint: 'http://127.0.0.1:8529'
@@ -34,7 +34,7 @@ class WalletClient extends BaseClient {
    * @param options - The options to send a message.
    * @returns The hash of the message.
    * @example
-   * import { WalletClient } from 'niljs';
+   * import { WalletClient } from '@nilfoundation/niljs';
    *
    * const client = new WalletClient({
    *  endpoint: 'http://127.0.0.1:8529'
@@ -93,7 +93,7 @@ class WalletClient extends BaseClient {
    * @param message - The message to send.
    * @returns The hash of the message.
    * @example
-   * import { WalletClient } from 'niljs';
+   * import { WalletClient } from '@nilfoundation/niljs';
    *
    * const client = new WalletClient({
    *  endpoint: 'http://127.0.0.1:8529'
@@ -116,7 +116,7 @@ class WalletClient extends BaseClient {
    * @param contract - The contract to deploy.
    * @returns The hash of the message.
    * @example
-   import { WalletClient } from 'niljs';
+   import { WalletClient } from '@nilfoundation/niljs';
    *
    * const client = new WalletClient({
    *  endpoint: 'http://127.0.0.1:8529'

--- a/src/clients/types/ClientConfigs.ts
+++ b/src/clients/types/ClientConfigs.ts
@@ -18,7 +18,7 @@ type IWalletClientConfig = IClientBaseConfig & {
    * The instance of signer is used to sign messages and messages.
    * If not included in the config, messages should be signed before passing to the client.
    * @example
-   * import { Signer } from 'niljs';
+   * import { Signer } from '@nilfoundation/niljs';
    *
    * const signer = new Signer();
    *

--- a/src/signers/LocalKeySigner.ts
+++ b/src/signers/LocalKeySigner.ts
@@ -11,7 +11,7 @@ import type { ISigner } from "./types/ISigner.js";
  * It is an abstraction of signing the data with the private key.
  * It uses the secp256k1 curve implementation by @noble/curves/secp256k1 library under the hood.
  * @example
- * import { LocalKeySigner, generatePrivateKey } from 'niljs';
+ * import { LocalKeySigner, generatePrivateKey } from '@nilfoundation/niljs';
  *
  * const privateKey = genratePrivateKey();
  * const signer = new LocalKeySigner({ privateKey });


### PR DESCRIPTION
Npm does not allow to publish packages with similar names.
It throws an error: `Package name too similar to existing package nil.js`.
Giving the package scope `@nilfoundation` does not hurt, maybe it is even more convenient.