### PR TITLE
Add polling receipt by hash

### DIFF
--- a/.changeset/serious-pants-carry.md
+++ b/.changeset/serious-pants-carry.md
@@ -1,0 +1,5 @@
+---
+"@nilfoundation/niljs": patch
+---
+
+Add simple polling implementation, allow to run publish workflow only manually, extend walletClient from publicClient

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
-      - master
   workflow_dispatch:
 
 concurrency:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nilfoundation/niljs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nilfoundation/niljs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@chainsafe/ssz": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=18.0.0"
   },
   "type": "module",
-  "main": "dist/niljs.cjs.cjs",
+  "main": "dist/niljs.cjs",
   "module": "dist/niljs.esm.js",
   "files": [
     "dist"
@@ -34,7 +34,8 @@
     "lint": "biome check .",
     "biome:fix": "biome check --apply .",
     "changeset": "changeset",
-    "changeset:publish": "npm run build && changeset publish"
+    "changeset:publish": "changeset publish",
+    "git-hooks:update": "git config core.hooksPath .git/hooks/ && rm -rf .git/hooks && npx --no-install simple-git-hooks"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/src/clients/PublicClient.ts
+++ b/src/clients/PublicClient.ts
@@ -1,3 +1,4 @@
+import type { IReceipt } from "../index.js";
 import { BaseClient } from "./BaseClient.js";
 import type { IPublicClientConfig } from "./types/ClientConfigs.js";
 
@@ -205,11 +206,47 @@ class PublicClient extends BaseClient {
 
     return res.result;
   }
+
+  /**
+   * getMessageReceiptByHash returns the message receipt by the hash.
+   * @param shardId - The shard id.
+   * @param hash - The hash.
+   * @returns The message receipt.
+   */
+  public async getMessageReceiptByHash(
+    shardId: number,
+    hash: Uint8Array,
+  ): Promise<IReceipt> {
+    const res = await this.rpcClient.request({
+      method: "eth_getMessageReceipt",
+      params: [shardId, hash],
+    });
+
+    return res.result;
+  }
+
+  /**
+   * sendRawMessage sends a raw message to the network.
+   * @param message - The message to send.
+   * @returns The hash of the message.
+   * @example
+   * import { PublicClient } from '@nilfoundation/niljs';
+   *
+   * const client = new PublicClient({
+   *  endpoint: 'http://127.0.0.1:8529'
+   * })
+   *
+   * const message = Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+   * const hash = await client.sendRawMessage(message);
+   */
+  public async sendRawMessage(message: Uint8Array): Promise<Uint8Array> {
+    const res = await this.rpcClient.request({
+      method: "eth_sendRawMessage",
+      params: [message],
+    });
+
+    return res.hash;
+  }
 }
 
 export { PublicClient };
-
-// this client is subject to change a lot
-// we need to add more methods to interact with the network
-// and we need to know shard id before executing the request
-// we won't have a single source of data for all shards so we need to know shard id.

--- a/src/clients/types/ClientConfigs.ts
+++ b/src/clients/types/ClientConfigs.ts
@@ -27,7 +27,7 @@ type IWalletClientConfig = IClientBaseConfig & {
    *  signer: signer
    * })
    */
-  signer?: ISigner;
+  signer: ISigner;
 };
 
 export type { IClientBaseConfig, IPublicClientConfig, IWalletClientConfig };

--- a/src/signers/LocalKeySigner.ts
+++ b/src/signers/LocalKeySigner.ts
@@ -1,7 +1,13 @@
+import type { Hex } from "@noble/curves/abstract/utils";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { toHex } from "../encoding/toHex.js";
-import { assertIsHexString, assertIsValidPrivateKey } from "../utils/assert.js";
-import { getPublicKey } from "./publicKey.js";
+import {
+  assertIsAddress,
+  assertIsHexString,
+  assertIsValidPrivateKey,
+} from "../utils/assert.js";
+import { getAddressFromPublicKey, getPublicKey } from "./publicKey.js";
+import type { IAddress } from "./types/IAddress.js";
 import type { ILocalKeySignerConfig } from "./types/ILocalKeySignerConfig.js";
 import type { ISignature } from "./types/ISignature.js";
 import type { ISigner } from "./types/ISigner.js";
@@ -17,17 +23,14 @@ import type { ISigner } from "./types/ISigner.js";
  * const signer = new LocalKeySigner({ privateKey });
  */
 class LocalKeySigner implements ISigner {
-  private publicKey;
   private privateKey;
+  private publicKey?: Hex = undefined;
+  private address?: IAddress = undefined;
 
   constructor(config: ILocalKeySignerConfig) {
     const { privateKey } = config;
     assertIsValidPrivateKey(privateKey);
 
-    const publicKey = getPublicKey(privateKey);
-    assertIsHexString(publicKey);
-
-    this.publicKey = publicKey;
     this.privateKey = privateKey;
   }
 
@@ -44,7 +47,26 @@ class LocalKeySigner implements ISigner {
   }
 
   public getPublicKey() {
+    if (this.publicKey) {
+      return this.publicKey;
+    }
+
+    const publicKey = getPublicKey(this.privateKey);
+    assertIsHexString(publicKey);
+
+    this.publicKey = publicKey;
     return this.publicKey;
+  }
+
+  public getAddress() {
+    if (this.address) {
+      return this.address;
+    }
+
+    this.address = getAddressFromPublicKey(this.getPublicKey());
+    assertIsAddress(this.address);
+
+    return this.address;
   }
 }
 

--- a/src/signers/publicKey.ts
+++ b/src/signers/publicKey.ts
@@ -4,8 +4,11 @@ import {
   type ISignature,
   addHexPrefix,
   removeHexPrefix,
+  toBytes,
   toHex,
 } from "../index.js";
+import { keccak_256 } from "../utils/keccak256.js";
+import type { IAddress } from "./types/IAddress.js";
 import type { IPrivateKey } from "./types/IPrivateKey.js";
 
 /**
@@ -31,4 +34,19 @@ const recoverPublicKey = (
   //
 };
 
-export { getPublicKey, generatePrivateKey, recoverPublicKey };
+/**
+ * Returns the address from the public key.
+ * @param publicKey - Public key in hex format
+ * @returns Address in hex format
+ */
+const getAddressFromPublicKey = (publicKey: Hex): IAddress => {
+  const bytes = keccak_256(toBytes(removeHexPrefix(publicKey)));
+  return toHex(bytes) as IAddress;
+};
+
+export {
+  getPublicKey,
+  generatePrivateKey,
+  recoverPublicKey,
+  getAddressFromPublicKey,
+};

--- a/src/signers/types/IAddress.ts
+++ b/src/signers/types/IAddress.ts
@@ -1,0 +1,6 @@
+/**
+ * Address type represents an address in hexadecimal format.
+ */
+type IAddress = `0x${string}`;
+
+export type { IAddress };

--- a/src/signers/types/ISigner.ts
+++ b/src/signers/types/ISigner.ts
@@ -1,4 +1,5 @@
 import type { Hex } from "@noble/curves/abstract/utils";
+import type { IAddress } from "./IAddress.js";
 import type { ISignature } from "./ISignature.js";
 
 /**
@@ -21,6 +22,13 @@ abstract class ISigner {
    * const publicKey = signer.getPublicKey();
    */
   abstract getPublicKey(): Hex;
+  /**
+   * Returns the address.
+   * @returns The address.
+   * @example
+   * const address = signer.getAddress();
+   */
+  abstract getAddress(): IAddress;
 }
 
 export { ISigner };

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -42,7 +42,7 @@ const assertIsValidPrivateKey = (
   message?: string,
 ): void => {
   invariant(
-    isHexString(privateKey) && privateKey.length === 64,
+    isHexString(privateKey) && privateKey.length === 32 * 2 + 2,
     message ?? `Expected a valid private key, but got ${privateKey}`,
   );
 };

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -7,8 +7,12 @@ const HEX_REGEX = /^[0-9a-fA-F]+$/;
  * Otherwise, it returns false.
  * @param value - The value to check.
  */
-const isHexString = (value: Hex): boolean => {
-  return typeof value === "string" && HEX_REGEX.test(value);
+const isHexString = (value: Hex): value is Hex => {
+  return (
+    typeof value === "string" &&
+    value.startsWith("0x") &&
+    HEX_REGEX.test(removeHexPrefix(value))
+  );
 };
 
 /**
@@ -16,8 +20,12 @@ const isHexString = (value: Hex): boolean => {
  * @param hex hex-string
  * @returns format: base16-string
  */
-const removeHexPrefix = (hex: string): string => {
-  return hex.replace(/^0x/i, "");
+const removeHexPrefix = (hex: Hex): string => {
+  if (typeof hex !== "string") {
+    throw new Error(`Expected a hex string but got ${hex}`);
+  }
+
+  return hex.startsWith("0x") ? hex.slice(2) : hex;
 };
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./assert.js";
 export * from "./hex.js";
 export * from "./message.js";
+export * from "./keccak256.js";

--- a/src/utils/keccak256.ts
+++ b/src/utils/keccak256.ts
@@ -1,0 +1,13 @@
+import type { Hex } from "@noble/curves/abstract/utils";
+import { keccak_256 as keccak_256Module } from "@noble/hashes/sha3";
+
+/**
+ * Returns the keccak-256 hash of the data. It is used in the Nil blockchain.
+ * @param data - The data to hash.
+ * @returns The keccak-256 hash.
+ */
+const keccak_256 = (data: Hex) => {
+  return keccak_256Module(data);
+};
+
+export { keccak_256 };

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -1,4 +1,5 @@
 import type { Hex } from "@noble/curves/abstract/utils";
+import type { IAddress } from "../signers/types/IAddress.js";
 
 const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
 
@@ -7,8 +8,20 @@ const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
  * Otherwise, it returns false.
  * @param value - The value to check.
  */
-const isAddress = (value: Hex): boolean => {
+const isAddress = (value: Hex): value is IAddress => {
   return typeof value === "string" && ADDRESS_REGEX.test(value);
 };
 
-export { isAddress };
+/**
+ * Returns the shard ID from the address.
+ * @param address - The address.
+ */
+const getShardIdFromAddress = (address: Hex): number => {
+  if (typeof address === "string") {
+    return Number.parseInt(address.slice(2, 6), 16);
+  }
+
+  return (address[0] << 8) | address[1];
+};
+
+export { isAddress, getShardIdFromAddress };

--- a/src/utils/polling.ts
+++ b/src/utils/polling.ts
@@ -1,0 +1,26 @@
+/**
+ * Polls a callback function until a condition is met.
+ * @param cb - Callback function to be executed
+ * @param condition - Condition to be met
+ * @param interval - Interval in milliseconds
+ * @returns Result of the callback function
+ */
+const startPollingUntilCondition = async <Result>(
+  cb: () => Promise<Result>,
+  condition: (result: Result) => boolean,
+  interval: number,
+) => {
+  let result: Result | undefined;
+
+  while (true) {
+    result = await cb();
+
+    if (condition(result)) {
+      return result;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+};
+
+export { startPollingUntilCondition };


### PR DESCRIPTION
This diff adds initial implementation of polling for transaction receipts. To get a receipt we need a shard it, so we implemented `getShardIdFromAddress` utility function. 
Also, this diff allows to run publish workflow only manually and introduces some minor updates in scripts.