### PR TITLE
Update biomejs and apply some code style rules

### DIFF
--- a/.changeset/unlucky-plums-jog.md
+++ b/.changeset/unlucky-plums-jog.md
@@ -1,0 +1,5 @@
+---
+"@nilfoundation/niljs": patch
+---
+
+Update biomejs and apply some code style rules

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.7.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.8.1/schema.json",
   "organizeImports": {
     "enabled": true
   },
@@ -11,7 +11,23 @@
         "noUnusedImports": "error"
       },
       "nursery": {
-        "noConsole": "warn"
+        "noConsole": "error"
+      },
+      "style": {
+        "noDefaultExport": "warn",
+        "useNamingConvention": {
+          "level": "warn",
+          "options": {
+            "strictCase": false,
+            "requireAscii": true,
+            "enumMemberCase": "PascalCase",
+            "conventions": [
+              {
+                "formats": ["camelCase", "PascalCase", "CONSTANT_CASE"]
+              }
+            ]
+          }
+        }
       }
     }
   },

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -14,4 +14,5 @@ const config = {
   defaultIgnores: false,
 } satisfies UserConfig;
 
+// biome-ignore lint/style/noDefaultExport: <explanation>
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nilfoundation/niljs",
-  "version": "0.1.4",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nilfoundation/niljs",
-      "version": "0.1.4",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@chainsafe/persistent-merkle-tree": "^0.7.2",
@@ -17,7 +17,7 @@
         "tiny-invariant": "^1.3.3"
       },
       "devDependencies": {
-        "@biomejs/biome": "^1.7.3",
+        "@biomejs/biome": "^1.8.1",
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.2",
         "@commitlint/cli": "^19.3.0",
@@ -147,9 +147,9 @@
       "dev": true
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.8.0.tgz",
-      "integrity": "sha512-34xcE2z8GWrIz1sCFEmlHT/+4d+SN7YOqqvzlAKXKvaWPRJ2/NUwxPbRsP01P9QODkQ5bvGvc9rpBihmP+7RJQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.8.1.tgz",
+      "integrity": "sha512-fQXGfvq6DIXem12dGQCM2tNF+vsNHH1qs3C7WeOu75Pd0trduoTmoO7G4ntLJ2qDs5wuw981H+cxQhi1uHnAtA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -163,20 +163,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.8.0",
-        "@biomejs/cli-darwin-x64": "1.8.0",
-        "@biomejs/cli-linux-arm64": "1.8.0",
-        "@biomejs/cli-linux-arm64-musl": "1.8.0",
-        "@biomejs/cli-linux-x64": "1.8.0",
-        "@biomejs/cli-linux-x64-musl": "1.8.0",
-        "@biomejs/cli-win32-arm64": "1.8.0",
-        "@biomejs/cli-win32-x64": "1.8.0"
+        "@biomejs/cli-darwin-arm64": "1.8.1",
+        "@biomejs/cli-darwin-x64": "1.8.1",
+        "@biomejs/cli-linux-arm64": "1.8.1",
+        "@biomejs/cli-linux-arm64-musl": "1.8.1",
+        "@biomejs/cli-linux-x64": "1.8.1",
+        "@biomejs/cli-linux-x64-musl": "1.8.1",
+        "@biomejs/cli-win32-arm64": "1.8.1",
+        "@biomejs/cli-win32-x64": "1.8.1"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.8.0.tgz",
-      "integrity": "sha512-dBAYzfIJ1JmWigKlWourT3sJ3I60LZPjqNwwlsyFjiv5AV7vPeWlHVVIImV2BpINwNjZQhpXnwDfVnGS4vr7AA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.8.1.tgz",
+      "integrity": "sha512-XLiB7Uu6GALIOBWzQ2aMD0ru4Ly5/qSeQF7kk3AabzJ/kwsEWSe33iVySBP/SS2qv25cgqNiLksjGcw2bHT3mw==",
       "cpu": [
         "arm64"
       ],
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.8.0.tgz",
-      "integrity": "sha512-ZTTSD0bP0nn9UpRDGQrQNTILcYSj+IkxTYr3CAV64DWBDtQBomlk2oVKWzDaA1LOhpAsTh0giLCbPJaVk2jfMQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.8.1.tgz",
+      "integrity": "sha512-uMTSxVLMfqkBVqyc25hSn83jBbp+wtWjzM/pHFlKXt3htJuw7FErVGW0nmQ9Sxa9vJ7GcqoltLMl28VQRIMYzg==",
       "cpu": [
         "x64"
       ],
@@ -206,9 +206,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.8.0.tgz",
-      "integrity": "sha512-cx725jTlJS6dskvJJwwCQaaMRBKE2Qss7ukzmx27Rn/DXRxz6tnnBix4FUGPf1uZfwrERkiJlbWM05JWzpvvXg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.8.1.tgz",
+      "integrity": "sha512-3SzZRuC/9Oi2P2IBNPsEj0KXxSXUEYRR2kfRF/Ve8QAfGgrt4qnwuWd6QQKKN5R+oYH691qjm+cXBKEcrP1v/Q==",
       "cpu": [
         "arm64"
       ],
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.8.0.tgz",
-      "integrity": "sha512-+ee/pZWsvhDv6eRI00krRNSgAg8DKSxzOv3LUsCjto6N1VzqatTASeQv2HRfG1nitf79rRKM75LkMJbqEfiKww==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.8.1.tgz",
+      "integrity": "sha512-UQ8Wc01J0wQL+5AYOc7qkJn20B4PZmQL1KrmDZh7ot0DvD6aX4+8mmfd/dG5b6Zjo/44QvCKcvkFGCMRYuhWZA==",
       "cpu": [
         "arm64"
       ],
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.8.0.tgz",
-      "integrity": "sha512-cmgmhlD4QUxMhL1VdaNqnB81xBHb3R7huVNyYnPYzP+AykZ7XqJbPd1KcWAszNjUk2AHdx0aLKEBwCOWemxb2g==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.8.1.tgz",
+      "integrity": "sha512-AeBycVdNrTzsyYKEOtR2R0Ph0hCD0sCshcp2aOnfGP0hCZbtFg09D0SdKLbyzKntisY41HxKVrydYiaApp+2uw==",
       "cpu": [
         "x64"
       ],
@@ -254,9 +254,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.8.0.tgz",
-      "integrity": "sha512-VPA4ocrAOak50VYl8gOAVnjuFFDpIUolShntc/aWM0pZfSIMbRucxnrfUfp44EVwayxjK6ruJTR5xEWj93WvDA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.8.1.tgz",
+      "integrity": "sha512-fYbP/kNu/rtZ4kKzWVocIdqZOtBSUEg9qUhZaao3dy3CRzafR6u6KDtBeSCnt47O+iLnks1eOR1TUxzr5+QuqA==",
       "cpu": [
         "x64"
       ],
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.8.0.tgz",
-      "integrity": "sha512-J31spvlh39FfRHQacYXxJX9PvTCH/a8+2Jx9D1lxw+LSF0JybqZcw/4JrlFUWUl4kF3yv8AuYUK0sENScc3g9w==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.8.1.tgz",
+      "integrity": "sha512-6tEd1H/iFKpgpE3OIB7oNgW5XkjiVMzMRPL8zYoZ036YfuJ5nMYm9eB9H/y81+8Z76vL48fiYzMPotJwukGPqQ==",
       "cpu": [
         "arm64"
       ],
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.8.0.tgz",
-      "integrity": "sha512-uPHHvu76JC1zYe9zZDcOU9PAg+1MZmPuNgWkb5jljaDeATvzLFPB+0nuJTilf603LXL+E8IdPQAO61Wy2VuEJA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.8.1.tgz",
+      "integrity": "sha512-g2H31jJzYmS4jkvl6TiyEjEX+Nv79a5km/xn+5DARTp5MBFzC9gwceusSSB2AkJKqZzY131AiACAWjKrVt5Ijw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@open-rpc/client-js": ">=1.8.1 <1.9.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.7.3",
+    "@biomejs/biome": "^1.8.1",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.2",
     "@commitlint/cli": "^19.3.0",

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitest/config";
 
+// biome-ignore lint/style/noDefaultExport: <explanation>
 export default defineConfig({
   test: {
     environment: "node",


### PR DESCRIPTION
This diff brings minor changes to code style mostly by allowing only camelCase and PascalCase for naming.
Also, it restricts `console` usage, because it is not a decent idea to spam in user terminal with console or expose some internal data in browser console. If we definitely need console in the code, we can always suppress this rule with `// biome-ignore lint/nursery/noConsole: <explanation>`