### PR TITLE
Improvements of changeset version workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,8 @@
 name: Release
 
 on:
+  pull_request:
+    types: [closed]
   workflow_dispatch:
 
 concurrency:
@@ -8,8 +10,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  version-pull-request:
-    name: Version Pull Request
+  release:
+    # Only run this job if the pull request was pull request from changesets
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.merged == true &&
+      github.event.pull_request.title == 'Version Packages' &&
+      github.event.pull_request.head.ref == 'master')
+    name: Release on GitHub and publish to npm
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -24,13 +32,12 @@ jobs:
           node_version: 20
       - name: Build
         uses: ./.github/actions/build
-      - name: Create Pull Request and Publish
+      - name: Create Release and Publish
         uses: changesets/action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.REPOSITORY_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         with:
-          title: "Version Packages"
-          commit: "version packages"
           createGithubReleases: true
           publish: "npm run changeset:publish"

--- a/.github/workflows/version_pull_request.yaml
+++ b/.github/workflows/version_pull_request.yaml
@@ -1,0 +1,36 @@
+name: Version pull request
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version-pull-request:
+    name: Version Pull Request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          node_version: 20
+      - name: Build
+        uses: ./.github/actions/build
+      - name: Create Pull Request with changeset
+        uses: changesets/action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPOSITORY_ACCESS_TOKEN }}
+        with:
+          title: "Version Packages"
+          commit: "version packages"


### PR DESCRIPTION
This diff improves process of version increment.
A bit more boilerplate but much more useful workflow for developers.
In a nutshell, now versions pull request will be created on every push to `master` if the commit contains new changesets. With every new commit pull request will be updated, which works out of the box with changesets.
After developer merge versions pull request, another workflow runs, which creates GitHub request and publishes new version to npm.

Previously it was required to run Release workflow twice and approve/merge pull request. Now it will be required only to approve and merge pull request.
Anyway, developers will still have an ability to dispatch workflow manually.