### PR TITLE
Add npm audit step to build workflow

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,6 +7,9 @@ runs:
     - name: Lint
       shell: bash
       run: npm run lint
+    - name: Npm audit
+      shell: bash
+      run: npm audit --audit-level=moderate
     # - name: Test
     #   shell: bash
     #   run: npm run test:ci


### PR DESCRIPTION
This diff adds `npm audit` step to build workflow. `moderate` level is set to skip low vulnerabilities.