### PR TITLE
Remove viem encoding

### DIFF
--- a/.changeset/fluffy-paws-float.md
+++ b/.changeset/fluffy-paws-float.md
@@ -1,0 +1,5 @@
+---
+"@nilfoundation/niljs": minor
+---
+
+Remove viem encoding and replace with local implementation

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: Release
 on:
   pull_request:
     types: [closed]
+    branches: [master]
   workflow_dispatch:
 
 concurrency:

--- a/examples/asyncCall.ts
+++ b/examples/asyncCall.ts
@@ -1,10 +1,10 @@
-import { bytesToHex } from "viem";
 import {
   Faucet,
   HttpTransport,
   LocalECDSAKeySigner,
   PublicClient,
   WalletV1,
+  bytesToHex,
   generateRandomPrivateKey,
   waitTillCompleted,
 } from "../src";

--- a/examples/bounce.ts
+++ b/examples/bounce.ts
@@ -1,10 +1,11 @@
-import { bytesToHex, encodeFunctionData } from "viem";
+import { encodeFunctionData } from "viem";
 import {
   Faucet,
   HttpTransport,
   LocalECDSAKeySigner,
   PublicClient,
   WalletV1,
+  bytesToHex,
   generateRandomPrivateKey,
   waitTillCompleted,
 } from "../src";

--- a/examples/deployInternalMessage.ts
+++ b/examples/deployInternalMessage.ts
@@ -1,11 +1,11 @@
 import type { Abi } from "abitype";
-import { bytesToHex } from "viem";
 import {
   Faucet,
   HttpTransport,
   LocalECDSAKeySigner,
   PublicClient,
   WalletV1,
+  bytesToHex,
   generateRandomPrivateKey,
   waitTillCompleted,
 } from "../src";

--- a/examples/deployWallet.ts
+++ b/examples/deployWallet.ts
@@ -1,10 +1,10 @@
-import { bytesToHex } from "viem";
 import {
   Faucet,
   HttpTransport,
   LocalECDSAKeySigner,
   PublicClient,
   WalletV1,
+  bytesToHex,
   generateRandomPrivateKey,
 } from "../src";
 

--- a/examples/externalContractDeployment.ts
+++ b/examples/externalContractDeployment.ts
@@ -1,10 +1,10 @@
-import { bytesToHex } from "viem";
 import {
   Faucet,
   HttpTransport,
   LocalECDSAKeySigner,
   PublicClient,
   WalletV1,
+  bytesToHex,
   externalDeploymentMessage,
   generateRandomPrivateKey,
 } from "../src";

--- a/examples/syncCall.ts
+++ b/examples/syncCall.ts
@@ -1,10 +1,10 @@
-import { bytesToHex } from "viem";
 import {
   Faucet,
   HttpTransport,
   LocalECDSAKeySigner,
   PublicClient,
   WalletV1,
+  bytesToHex,
   convertEthToWei,
   generateRandomPrivateKey,
 } from "../src";

--- a/examples/tokenMint.ts
+++ b/examples/tokenMint.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, encodeFunctionData, hexToBigInt } from "viem";
+import { encodeFunctionData } from "viem";
 import {
   Faucet,
   HttpTransport,
@@ -7,7 +7,9 @@ import {
   MINTER_ADDRESS,
   PublicClient,
   WalletV1,
+  bytesToHex,
   generateRandomPrivateKey,
+  hexToBigInt,
   waitTillCompleted,
 } from "../src";
 

--- a/src/clients/PublicClient.ts
+++ b/src/clients/PublicClient.ts
@@ -1,6 +1,10 @@
-import { bytesToHex } from "@noble/curves/abstract/utils";
-import { hexToBytes, numberToHex } from "viem";
-import { hexToBigInt, hexToNumber } from "../encoding/index.js";
+import {
+  bytesToHex,
+  hexToBigInt,
+  hexToBytes,
+  hexToNumber,
+  toHex,
+} from "../encoding/index.js";
 import { BlockNotFoundError } from "../errors/block.js";
 import { type Hex, assertIsValidShardId } from "../index.js";
 import type { IAddress } from "../signers/types/IAddress.js";
@@ -410,7 +414,7 @@ class PublicClient extends BaseClient {
         typeof callArgs.data === "string"
           ? callArgs.data
           : addHexPrefix(bytesToHex(callArgs.data)),
-      value: numberToHex(callArgs.value || 0n),
+      value: toHex(callArgs.value || 0n),
       gasLimit: (callArgs.gasLimit || 5_000_000n).toString(10),
     };
 

--- a/src/contracts/Faucet/Faucet.test.ts
+++ b/src/contracts/Faucet/Faucet.test.ts
@@ -1,13 +1,15 @@
-import { bytesToHex } from "viem";
-import { generatePrivateKey } from "viem/accounts";
 import { PublicClient } from "../../clients/index.js";
-import { LocalECDSAKeySigner } from "../../signers/index.js";
+import { bytesToHex } from "../../index.js";
+import {
+  LocalECDSAKeySigner,
+  generateRandomPrivateKey,
+} from "../../signers/index.js";
 import { MockTransport } from "../../transport/MockTransport.js";
 import { WalletV1 } from "../WalletV1/WalletV1.js";
 import { Faucet } from "./Faucet.js";
 
 const signer = new LocalECDSAKeySigner({
-  privateKey: generatePrivateKey(),
+  privateKey: generateRandomPrivateKey(),
 });
 
 test("Faucet with retry", async () => {

--- a/src/contracts/Faucet/Faucet.ts
+++ b/src/contracts/Faucet/Faucet.ts
@@ -1,6 +1,7 @@
-import { type Hex, bytesToHex, encodeFunctionData, hexToBytes } from "viem";
+import { type Hex, bytesToHex, encodeFunctionData } from "viem";
 import type { PublicClient } from "../../clients/PublicClient.js";
 import { ExternalMessageEnvelope } from "../../encoding/externalMessage.js";
+import { hexToBytes } from "../../index.js";
 import type { IReceipt } from "../../types/IReceipt.js";
 import { getShardIdFromAddress } from "../../utils/address.js";
 import { waitTillCompleted } from "../../utils/receipt.js";
@@ -9,7 +10,6 @@ import FaucetAbi from "./Faucet.abi.json";
 /**
  * Faucet is a special contract that is used to top up other contracts in the =nil; devnet.
  *
- 
  * @class Faucet
  * @typedef {Faucet}
  */

--- a/src/contracts/WalletV1/WalletV1.test.ts
+++ b/src/contracts/WalletV1/WalletV1.test.ts
@@ -1,12 +1,12 @@
-import { generatePrivateKey } from "viem/accounts";
 import { PublicClient } from "../../clients/index.js";
+import { generateRandomPrivateKey } from "../../index.js";
 import { LocalECDSAKeySigner } from "../../signers/LocalECDSAKeySigner.js";
 import { MockTransport } from "../../transport/MockTransport.js";
 import { HttpTransport } from "../../transport/index.js";
 import { WalletV1 } from "./WalletV1.js";
 
 const signer = new LocalECDSAKeySigner({
-  privateKey: generatePrivateKey(),
+  privateKey: generateRandomPrivateKey(),
 });
 const pubkey = await signer.getPublicKey();
 const client = new PublicClient({

--- a/src/contracts/WalletV1/WalletV1.ts
+++ b/src/contracts/WalletV1/WalletV1.ts
@@ -1,9 +1,10 @@
 import type { Abi } from "abitype";
 import invariant from "tiny-invariant";
-import { bytesToHex, encodeFunctionData, hexToBytes } from "viem";
+import { bytesToHex, encodeFunctionData } from "viem";
 import type { PublicClient } from "../../clients/PublicClient.js";
 import { prepareDeployPart } from "../../encoding/deployPart.js";
 import { externalMessageEncode } from "../../encoding/externalMessage.js";
+import { hexToBytes, toHex } from "../../index.js";
 import type { ISigner } from "../../signers/index.js";
 import type { IDeployData } from "../../types/IDeployData.js";
 import { getShardIdFromAddress, refineAddress } from "../../utils/address.js";
@@ -19,9 +20,8 @@ import type {
 } from "./types/index.js";
 
 /**
- * WalletV1 is a class used for performing operations on the cluster that require authentication. 
+ * WalletV1 is a class used for performing operations on the cluster that require authentication.
  *
- 
  * @class WalletV1
  * @typedef {WalletV1}
  */
@@ -166,7 +166,7 @@ export class WalletV1 {
     if (salt) {
       this.salt = refineSalt(salt);
     }
-    this.shardId = getShardIdFromAddress(this.address);
+    this.shardId = getShardIdFromAddress(toHex(this.address));
   }
 
   /**

--- a/src/encoding/deployPart.ts
+++ b/src/encoding/deployPart.ts
@@ -1,7 +1,9 @@
-import { bytesToHex, encodeDeployData, hexToBytes } from "viem";
+import { encodeDeployData } from "viem";
 import type { IDeployData } from "../types/IDeployData.js";
 import { calculateAddress } from "../utils/address.js";
 import { refineSalt } from "../utils/refiners.js";
+import { bytesToHex } from "./fromBytes.js";
+import { hexToBytes } from "./fromHex.js";
 
 /**
  * Refines the provided salt and generates the full bytecode for deployment. Returns the bytecode and the deployment address.

--- a/src/encoding/externalMessage.ts
+++ b/src/encoding/externalMessage.ts
@@ -1,15 +1,14 @@
-import { bytesToHex } from "viem";
 import type { PublicClient } from "../clients/PublicClient.js";
 import type { ISigner } from "../signers/index.js";
 import type { ExternalMessage } from "../types/ExternalMessage.js";
 import type { IDeployData } from "../types/IDeployData.js";
 import { prepareDeployPart } from "./deployPart.js";
+import { bytesToHex } from "./fromBytes.js";
 import { SszMessageSchema, SszSignedMessageSchema } from "./ssz.js";
 
 /**
  * The envelope for an external message (a message sent by a user, a dApp, etc.)
  *
- 
  * @class ExternalMessageEnvelope
  * @typedef {ExternalMessageEnvelope}
  */
@@ -206,7 +205,6 @@ export class ExternalMessageEnvelope {
 /**
  * The envelope for an internal message (a message sent by a smart contract to another smart contract).
  *
- 
  * @class InternalMessageEnvelope
  * @typedef {InternalMessageEnvelope}
  */

--- a/src/encoding/fromBytes.ts
+++ b/src/encoding/fromBytes.ts
@@ -1,13 +1,20 @@
+import { type Hex, toHex } from "../index.js";
+
+const decoder = new TextDecoder("utf8");
+
 /**
  * Converts bytes to a string.
  * @param bytes - The bytes to convert.
  * @returns The string representation of the input.
  */
 const bytesToString = (bytes: Uint8Array): string => {
-  const decoder = new TextDecoder("utf8");
   const str = decoder.decode(bytes);
 
   return str;
 };
 
-export { bytesToString };
+const bytesToHex = (bytes: Uint8Array): Hex => {
+  return toHex(bytes);
+};
+
+export { bytesToString, bytesToHex };

--- a/src/encoding/fromHex.test.ts
+++ b/src/encoding/fromHex.test.ts
@@ -1,11 +1,13 @@
-import { hexToBigInt, hexToNumber } from "./fromHex.js";
+import { hexToBigInt, hexToBytes, hexToNumber } from "./fromHex.js";
 
 test("hexToBigInt", () => {
   expect(hexToBigInt("0x7b")).toBe(123n);
-  expect(hexToBigInt("7b")).toBe(123n);
 });
 
 test("hexToNumber", () => {
   expect(hexToNumber("0x7b")).toBe(123);
-  expect(hexToNumber("7b")).toBe(123);
+});
+
+test("hexToBytes", () => {
+  expect(hexToBytes("0x7b")).toEqual(Uint8Array.from([123]));
 });

--- a/src/encoding/fromHex.ts
+++ b/src/encoding/fromHex.ts
@@ -1,5 +1,24 @@
+import { BaseError } from "../errors/BaseError.js";
 import type { Hex } from "../index.js";
 import { addHexPrefix, removeHexPrefix } from "../utils/hex.js";
+
+/**
+ * Convert a character code to a base16 number.
+ * @param charCode - The character code to convert.
+ * @returns The base16 representation of the input.
+ */
+const charCodeToBase16 = (charCode: number): number | undefined => {
+  if (charCode >= 48 && charCode <= 57) {
+    return charCode - 48;
+  }
+  if (charCode >= 65 && charCode <= 70) {
+    return charCode - 55;
+  }
+  if (charCode >= 97 && charCode <= 102) {
+    return charCode - 87;
+  }
+  return undefined;
+};
 
 /**
  * Convert a hex string to a number.
@@ -19,4 +38,28 @@ const hexToBigInt = (hex: Hex): bigint => {
   return BigInt(addHexPrefix(hex));
 };
 
-export { hexToNumber, hexToBigInt };
+const hexToBytes = (hex: Hex): Uint8Array => {
+  let hexString = hex.slice(2);
+  if (hexString.length % 2) {
+    hexString = `0${hexString}`;
+  }
+
+  const length = hexString.length / 2;
+  const bytes = new Uint8Array(length);
+
+  for (let index = 0, j = 0; index < length; index++) {
+    const nibbleLeft = charCodeToBase16(hexString.charCodeAt(j++));
+    const nibbleRight = charCodeToBase16(hexString.charCodeAt(j++));
+    if (nibbleLeft === undefined || nibbleRight === undefined) {
+      throw new BaseError(
+        `Invalid byte sequence ("${hexString[j - 2]}${
+          hexString[j - 1]
+        }" in "${hexString}").`,
+      );
+    }
+    bytes[index] = nibbleLeft * 16 + nibbleRight;
+  }
+  return bytes;
+};
+
+export { hexToNumber, hexToBigInt, hexToBytes };

--- a/src/encoding/toHex.test.ts
+++ b/src/encoding/toHex.test.ts
@@ -2,10 +2,13 @@ import { toHex } from "./toHex.js";
 
 test("should convert a string to hex", () => {
   expect(toHex("hello")).toBe("0x68656c6c6f");
+  expect(toHex("")).toBe("0x");
+  expect(toHex("some string")).toBe("0x736f6d6520737472696e67");
 });
 
 test("should convert a number to hex", () => {
   expect(toHex(123)).toBe("0x7b");
+  expect(toHex(0)).toBe("0x0");
 });
 
 test("should convert a bigint to hex", () => {

--- a/src/encoding/toHex.ts
+++ b/src/encoding/toHex.ts
@@ -1,45 +1,82 @@
-import { bytesToHex, numberToHexUnpadded } from "@noble/curves/abstract/utils";
+import { type Hex, IntegerOutOfRangeError, addHexPrefix } from "../index.js";
+
+// biome-ignore lint/style/useNamingConvention: <explanation>
+const hexes = Array.from({ length: 256 }, (_, i) =>
+  i.toString(16).padStart(2, "0"),
+);
 
 /**
  * Convert a string to a hex string.
  * @param str - The input string to convert.
  * @returns The hex string representation of the input.
  */
-const stringToHex = (str: string): string => {
+const stringToHex = (str: string): Hex => {
   let hex = "";
 
   for (let i = 0; i < str.length; i++) {
     hex += str.charCodeAt(i).toString(16);
   }
 
-  return hex;
+  return addHexPrefix(hex);
+};
+
+/**
+ * Convert bytes to a hex string.
+ * @param bytes - The bytes to convert.
+ * @returns The hex string representation of the input.
+ */
+const bytesToHex = (bytes: Uint8Array): Hex => {
+  let hex = "";
+
+  for (let i = 0; i < bytes.length; i++) {
+    hex += hexes[bytes[i]];
+  }
+
+  return addHexPrefix(hex);
+};
+
+/**
+ * Convert an unsigned number to a hex string.
+ * @param num - The number to convert.
+ * @returns The hex string representation of the input.
+ */
+const numberToHex = (num: number | bigint): Hex => {
+  const value = BigInt(num);
+  const maxValue = BigInt(Number.MAX_SAFE_INTEGER);
+  const minValue = 0;
+
+  if ((maxValue && value > maxValue) || value < minValue) {
+    throw new IntegerOutOfRangeError({
+      max: maxValue,
+      min: minValue,
+      value,
+    });
+  }
+
+  return addHexPrefix(value.toString(16));
 };
 
 /**
  * Convert a string, number, bigint, boolean, or ByteArrayType to a hex string.
- * @param str - The input string to convert.
+ * @param value - The input to convert.
  * @returns The hex string representation of the input.
  */
-const toHex = <T extends string | number | bigint | boolean | Uint8Array>(
+const toHex = <T extends string | Uint8Array | boolean | bigint | number>(
   value: T,
-): `0x${string}` => {
+): Hex => {
   if (typeof value === "string") {
-    return `0x${stringToHex(value)}`;
+    return stringToHex(value);
   }
 
-  if (typeof value === "number") {
-    return `0x${numberToHexUnpadded(value)}`;
+  if (value instanceof Uint8Array) {
+    return bytesToHex(value);
   }
 
-  if (typeof value === "bigint") {
-    return `0x${numberToHexUnpadded(value)}`;
+  if (typeof value === "number" || typeof value === "bigint") {
+    return numberToHex(value);
   }
 
-  if (typeof value === "boolean") {
-    return `0x${(value ? 1 : 0).toString(16)}`;
-  }
-
-  return `0x${bytesToHex(value)}`;
+  return addHexPrefix((value ? 1 : 0).toString(16));
 };
 
 export { toHex };

--- a/src/errors/encoding.ts
+++ b/src/errors/encoding.ts
@@ -1,0 +1,33 @@
+import { BaseError, type IBaseErrorParameters } from "./BaseError.js";
+
+/**
+ * The interface for the parameters of the {@link BlockNotFoundError} constructor.
+ */
+type IntegerOutOfRangeErrorParameters = {
+  max?: number | bigint;
+  min: number | bigint;
+  value: number | bigint;
+} & IBaseErrorParameters;
+
+/**
+ * The error class for 'integer out of range' errors.
+ * This error is thrown when the requested integer is out of range.
+ */
+class IntegerOutOfRangeError extends BaseError {
+  /**
+   * Creates an instance of IntegerOutOfRangeError.
+   *
+   * @constructor
+   * @param {IntegerOutOfRangeErrorParameters} param0 The error params.
+   * @param {*} param0.max The maximum value.
+   * @param {string} param0.min The minimum value.
+   */
+  constructor({ max, min, value, ...rest }: IntegerOutOfRangeErrorParameters) {
+    super(
+      `Number "${value}" is not in safe integer range ${max ? `(${min} to ${max})` : `(above ${min})`}`,
+      { ...rest },
+    );
+  }
+}
+
+export { IntegerOutOfRangeError };

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,2 +1,3 @@
 export * from "./block.js";
 export * from "./shardId.js";
+export * from "./encoding.js";

--- a/src/integrations/calling.test.ts
+++ b/src/integrations/calling.test.ts
@@ -1,4 +1,3 @@
-import { bytesToHex } from "viem";
 import { testEnv } from "../../test/testEnv.js";
 import {
   Faucet,
@@ -6,6 +5,7 @@ import {
   LocalECDSAKeySigner,
   PublicClient,
   WalletV1,
+  bytesToHex,
   convertEthToWei,
   generateRandomPrivateKey,
   waitTillCompleted,

--- a/src/integrations/deploy.test.ts
+++ b/src/integrations/deploy.test.ts
@@ -1,5 +1,4 @@
 import type { Abi } from "abitype";
-import { bytesToHex } from "viem";
 import { testEnv } from "../../test/testEnv.js";
 import {
   Faucet,
@@ -7,6 +6,7 @@ import {
   LocalECDSAKeySigner,
   PublicClient,
   WalletV1,
+  bytesToHex,
   convertEthToWei,
   externalDeploymentMessage,
   generateRandomPrivateKey,

--- a/src/integrations/tokens.test.ts
+++ b/src/integrations/tokens.test.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, encodeFunctionData, hexToBigInt, numberToHex } from "viem";
+import { encodeFunctionData } from "viem";
 import { testEnv } from "../../test/testEnv.js";
 import {
   Faucet,
@@ -8,8 +8,11 @@ import {
   MINTER_ADDRESS,
   PublicClient,
   WalletV1,
+  bytesToHex,
   convertEthToWei,
   generateRandomPrivateKey,
+  hexToBigInt,
+  toHex,
   waitTillCompleted,
 } from "../index.js";
 const client = new PublicClient({
@@ -61,8 +64,8 @@ test("mint and transfer tokens", async () => {
 
   expect(tokens).toBeDefined();
   expect(Object.keys(tokens).length).toBeGreaterThan(0);
-  expect(tokens[numberToHex(n)]).toBeDefined();
-  expect(tokens[numberToHex(n)]).toBe(mintCount);
+  expect(tokens[toHex(n)]).toBeDefined();
+  expect(tokens[toHex(n)]).toBe(mintCount);
 
   const anotherAddress = WalletV1.calculateWalletAddress({
     pubKey: pubkey,
@@ -93,6 +96,6 @@ test("mint and transfer tokens", async () => {
 
   expect(anotherTokens).toBeDefined();
   expect(Object.keys(anotherTokens).length).toBeGreaterThan(0);
-  expect(anotherTokens[numberToHex(n)]).toBeDefined();
-  expect(anotherTokens[numberToHex(n)]).toBe(transferCount);
+  expect(anotherTokens[toHex(n)]).toBeDefined();
+  expect(anotherTokens[toHex(n)]).toBe(transferCount);
 });

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,7 +1,7 @@
-import { bytesToHex } from "viem";
 import type { PublicClient } from "./clients/PublicClient.js";
 import { prepareDeployPart } from "./encoding/deployPart.js";
 import { SszMessageSchema, SszSignedMessageSchema } from "./encoding/ssz.js";
+import { bytesToHex } from "./index.js";
 import type { ISigner } from "./signers/index.js";
 import type { ExternalMessage } from "./types/ExternalMessage.js";
 import type { IDeployData } from "./types/IDeployData.js";
@@ -9,7 +9,6 @@ import type { IDeployData } from "./types/IDeployData.js";
 /**
  * The envelope for an external message (a message sent by a user, a dApp, etc.)
  *
- 
  * @class ExternalMessageEnvelope
  * @typedef {ExternalMessageEnvelope}
  */

--- a/src/signers/LocalECDSAKeySigner.test.ts
+++ b/src/signers/LocalECDSAKeySigner.test.ts
@@ -1,5 +1,5 @@
-import { bytesToHex } from "viem";
 import { accounts } from "../../test/mocks/accounts.js";
+import { bytesToHex } from "../index.js";
 import { LocalECDSAKeySigner } from "./LocalECDSAKeySigner.js";
 
 test("getPublicKey", async () => {

--- a/src/signers/LocalECDSAKeySigner.ts
+++ b/src/signers/LocalECDSAKeySigner.ts
@@ -1,7 +1,7 @@
 import { concatBytes, numberToBytesBE } from "@noble/curves/abstract/utils";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import invariant from "tiny-invariant";
-import { type Hex, bytesToHex, hexToBytes } from "viem";
+import { type Hex, bytesToHex, hexToBytes } from "../index.js";
 import { assertIsValidPrivateKey } from "../utils/assert.js";
 import { addHexPrefix, removeHexPrefix } from "../utils/hex.js";
 import { privateKeyFromPhrase } from "./mnemonic.js";

--- a/src/types/IDeployData.ts
+++ b/src/types/IDeployData.ts
@@ -1,5 +1,5 @@
 import type { Abi } from "abitype";
-import type { Hex } from "viem";
+import type { Hex } from "./Hex.js";
 
 /**
  * IDeployData is a data structure that contains information to deploy a contract.

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,6 +1,6 @@
-import { type Hex, numberToBytesBE } from "@noble/curves/abstract/utils";
-import { hexToBytes } from "viem";
+import { numberToBytesBE } from "@noble/curves/abstract/utils";
 import { poseidonHash } from "../encoding/poseidon.js";
+import { hexToBytes } from "../index.js";
 import type { IAddress } from "../signers/types/IAddress.js";
 
 /**
@@ -14,7 +14,7 @@ const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
  * Otherwise, returns false.
  * @param value The value to check.
  */
-const isAddress = (value: Hex): value is IAddress => {
+const isAddress = (value: string): value is IAddress => {
   return typeof value === "string" && ADDRESS_REGEX.test(value);
 };
 
@@ -22,7 +22,7 @@ const isAddress = (value: Hex): value is IAddress => {
  * Returns the ID of the shard containing the provided address.
  * @param address The address.
  */
-const getShardIdFromAddress = (address: Hex): number => {
+const getShardIdFromAddress = (address: string): number => {
   if (typeof address === "string") {
     return Number.parseInt(address.slice(2, 6), 16);
   }

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -33,4 +33,16 @@ const addHexPrefix = (str: Hex | string): Hex => {
   return `0x${removeHexPrefix(str)}`;
 };
 
-export { isHexString, removeHexPrefix, addHexPrefix };
+/**
+ * Concatenates an array of hex strings. The hex strings are concatenated without the "0x" prefix.
+ * The resulting hex string will have the "0x" prefix.
+ * @param values - An array of hex strings.
+ * @returns The concatenated hex string.
+ */
+const concatHex = (values: readonly Hex[]): Hex => {
+  return addHexPrefix(
+    (values as Hex[]).reduce((acc, x) => acc + x.replace("0x", ""), ""),
+  );
+};
+
+export { isHexString, removeHexPrefix, addHexPrefix, concatHex };

--- a/src/utils/refiners.ts
+++ b/src/utils/refiners.ts
@@ -1,5 +1,5 @@
 import invariant from "tiny-invariant";
-import { hexToBytes } from "viem";
+import { hexToBytes } from "../index.js";
 import { addHexPrefix } from "./hex.js";
 
 const refineSalt = (salt: Uint8Array | bigint): Uint8Array => {


### PR DESCRIPTION
This diff replaces all `viem` api except `encodeFunctionData` in the codebase. Some encoding methods added.
Related to #53 but not closing yet.