### PR TITLE
fix: fix Block Type for the sdk

### DIFF
--- a/.changeset/short-goats-act.md
+++ b/.changeset/short-goats-act.md
@@ -1,0 +1,5 @@
+---
+"@nilfoundation/niljs": patch
+---
+
+fix `Block` type to match with data returned from the RPC.

--- a/src/clients/PublicClient.ts
+++ b/src/clients/PublicClient.ts
@@ -69,7 +69,7 @@ class PublicClient extends BaseClient {
     assertIsValidShardId(shardId);
 
     try {
-      return await this.request<Block>({
+      return await this.request<Block<typeof fullTx>>({
         method: "eth_getBlockByHash",
         params: [shardId, hash, fullTx],
       });
@@ -104,7 +104,7 @@ class PublicClient extends BaseClient {
     assertIsValidShardId(shardId);
 
     try {
-      return await this.request<Block>({
+      return await this.request<Block<typeof fullTx>>({
         method: "eth_getBlockByNumber",
         params: [shardId, blockNumber, fullTx],
       });

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -1,21 +1,18 @@
 import type { Hex } from "./Hex.js";
+import type { ProcessedMessage } from "./ProcessedMessage.js";
 
 /**
  * The block type.
+ * Type `T` determines whether the block contains processed messages or just message hashes.
  */
-type Block = {
-  id: string;
-  prevBlock: Hex;
-  smartContractsRoot: Hex;
+type Block<T> = {
+  number: number;
+  hash: Hex;
+  parentHash: Hex;
   inMessagesRoot: Hex;
-  outMessagesRoot: Hex;
-  outMessagesNum: number;
   receiptsRoot: Hex;
-  childBlocksRootHash: string;
-  masterChainHash: Hex;
-  // biome-ignore lint/suspicious/noExplicitAny: need to investigate
-  logsBloom: any;
-  timestamp: number;
+  shardId: number;
+  messages: T extends true ? Array<ProcessedMessage> : Array<Hex>;
 };
 
 /**

--- a/src/types/Block.ts
+++ b/src/types/Block.ts
@@ -5,7 +5,7 @@ import type { ProcessedMessage } from "./ProcessedMessage.js";
  * The block type.
  * Type `T` determines whether the block contains processed messages or just message hashes.
  */
-type Block<T> = {
+type Block<T = false> = {
   number: number;
   hash: Hex;
   parentHash: Hex;


### PR DESCRIPTION
closes #91 

It uses conditional type to for messages to make sure that if the `fullTx` is set to true, then we get full processed messages, otherwise the type system just types it as an array of hex values.