### PR TITLE
fix: fix message `receipt` type to be compliant with the RPC spec

### DIFF
--- a/src/clients/PublicClient.ts
+++ b/src/clients/PublicClient.ts
@@ -304,7 +304,6 @@ class PublicClient extends BaseClient {
       return {
         ...receipt,
         gasUsed: BigInt(receipt.gasUsed),
-        gasPrice: BigInt(receipt.gasPrice),
         outputReceipts:
           receipt.outputReceipts?.map((x) => {
             if (x === null) {

--- a/src/types/IReceipt.ts
+++ b/src/types/IReceipt.ts
@@ -7,7 +7,6 @@ import type { ILog } from "./ILog.js";
 type IReceipt = {
   success: boolean;
   gasUsed: string;
-  gasPrice: string;
   bloom: string;
   logs: ILog[];
   messageHash: Hex;
@@ -20,12 +19,8 @@ type IReceipt = {
   shardId: number;
 };
 
-type ProcessedReceipt = Omit<
-  IReceipt,
-  "gasUsed" | "gasPrice" | "outputReceipts"
-> & {
+type ProcessedReceipt = Omit<IReceipt, "gasUsed" | "outputReceipts"> & {
   gasUsed: bigint;
-  gasPrice: bigint;
   outputReceipts: (ProcessedReceipt | null)[] | null;
 };
 


### PR DESCRIPTION
closes #102 

This PR, after merge, makes the message receipt type on the library compliant with the RPC spec; it will also resolve the issue of `waitTillCompleted` not working as it operates on the `gasPrice` field of `IReceipt`, which doesn't exist according to rpc spec.