### PR TITLE
fix: fix masterShardId being assigned to shard 0

### DIFF
--- a/src/clients/constants.ts
+++ b/src/clients/constants.ts
@@ -1,4 +1,5 @@
 const emptyAddress = "0x0000000000000000000000000000000000000000";
-const masterShardId = 0;
+// TODO: as of devnet there is not master shard, this constant should be updated once we have a master shard
+const masterShardId = 2 ** 16 - 1;
 
 export { emptyAddress, masterShardId };


### PR DESCRIPTION
closes #106 

- This PR changes the connstant for master ID to a different value
- Adds a TODO to make sure that once the master shard is activated, this field is updated
- This will allow for deployment of wallets to work on shard 0.