### PR TITLE
fix: invariant logic for Wallet 

### DIFF
--- a/src/contracts/WalletV1/WalletV1.ts
+++ b/src/contracts/WalletV1/WalletV1.ts
@@ -432,7 +432,7 @@ export class WalletV1 {
       };
     } else {
       invariant(
-        (abi && args) || (!abi && !args),
+        !(abi || args),
         "ABI and args should be provided together or not provided at all.",
       );
       deployData = {

--- a/src/contracts/WalletV1/WalletV1.ts
+++ b/src/contracts/WalletV1/WalletV1.ts
@@ -432,7 +432,7 @@ export class WalletV1 {
       };
     } else {
       invariant(
-        abi || args,
+        (abi && args) || (!abi && !args),
         "ABI and args should be provided together or not provided at all.",
       );
       deployData = {


### PR DESCRIPTION
Here is the code that will fail with the error: `Error: Invariant failed: ABI and args should be provided together or not provided at all.`

```
  const contract = await wallet.deployContract({
    bytecode: artifact.bytecode,
    shardId,
    salt: 1n,
    feeCredit: 0n,
  });
```

According to the message, it should work fine without both – abi and args. This is the fix