### PR TITLE
Fixed License Link Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 - [Installation](#installation)
 - [Getting started](#getting-started)
 - [Usage](#usage)
-- [License](#license)
+- [Licence](#licence)
 
 ### Installation
 
@@ -190,4 +190,4 @@ await waitTillCompleted(client, 1, sendHash);
 
 ## Licence
 
-[MIT](./LICENSE)
+[MIT](./LICENCE)


### PR DESCRIPTION
Fixed License Link Typo

The license link in the README was incorrectly labeled as "Licence" instead of "License." This PR corrects the typo, ensuring the link works as intended.