### PR TITLE
Fix for message by hash getter

### DIFF
--- a/src/clients/PublicClient.ts
+++ b/src/clients/PublicClient.ts
@@ -244,7 +244,7 @@ class PublicClient extends BaseClient {
     return {
       ...res,
       value: BigInt(res.value),
-      gasLimit: BigInt(res.gasLimit),
+      feeCredit: res.feeCredit ? BigInt(res.feeCredit) : 0n,
       gasUsed: hexToBigInt(res.gasUsed),
       seqno: hexToBigInt(res.seqno),
       index: res.index ? hexToNumber(res.index) : 0,

--- a/src/types/ProcessedMessage.ts
+++ b/src/types/ProcessedMessage.ts
@@ -14,7 +14,7 @@ export type ProcessedMessage = {
   blockNumber: number;
   from: Address;
   gasUsed: bigint;
-  gasLimit: bigint;
+  feeCredit: bigint;
   hash: Hex;
   seqno: bigint;
   to: Address;

--- a/src/types/RPCMessage.ts
+++ b/src/types/RPCMessage.ts
@@ -13,7 +13,7 @@ export type RPCMessage = {
   blockNumber: number;
   from: Hex;
   gasUsed: Hex;
-  gasLimit: string;
+  feeCredit: string;
   hash: Hex;
   seqno: Hex;
   to: Hex;


### PR DESCRIPTION
This PR introduces just an error fix for `client.getMessageByHash` that would throw a `BigInt` conversion of undefined error, as the RPC returns different types now. 

Message type returned by the RPC at the moment of authoring:

```
{
  "flags": [
    "External",
    "Deploy"
  ],
  "success": true,
  "requestId": 0,
  "data": ".................",
  "blockHash": "0x000187ab2adbf761920d940dc4a9cf7415237ec2d349c55ff823fe3eabe073dd",
  "blockNumber": 309777,
  "from": "0x0001150836953542b6e448d281408557c2c77ee8",
  "gasUsed": "63798",
  "feeCredit": "50000000",
  "hash": "0x0001e8a5ec5fed3326858310415d1cf5febfec85f0f7458b74833bd0253cd847",
  "seqno": "0x0",
  "to": "0x0001150836953542b6e448d281408557c2c77ee8",
  "refundTo": "0x0000000000000000000000000000000000000000",
  "bounceTo": "0x0000000000000000000000000000000000000000",
  "index": "0x0",
  "value": "0",
  "signature": "0x6f33c2db50054f87bcf5435c82796455ce494b81873e8c1b09eb713cc64c69a264e7ec863d7d9f38bbaaf303f7067d8e64d5f954107263fbc005f5991ae90a9a01"
}
```